### PR TITLE
Pin adminjs version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Adapter & Plugin package to use [AdminJS](https://adminjs.co/) with [AdonisJS](h
 ```bash
 # using npm:
 
-npm install --save adminjs-adonis adminjs
+npm install --save adminjs-adonis adminjs@6.8.7
 
 # or using yarn:
-yarn add adminjs-adonis adminjs
+yarn add adminjs-adonis adminjs@6.8.7
 ```
 
 After this, run:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Adapter & Plugin package to use [AdminJS](https://adminjs.co/) with [AdonisJS](h
 ```bash
 # using npm:
 
-npm install --save adminjs-adonis adminjs@6.8.7
+npm install --save adminjs-adonis adminjs@^6.0.0
 
 # or using yarn:
 yarn add adminjs-adonis adminjs@6.8.7

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Adapter & Plugin package to use [AdminJS](https://adminjs.co/) with [AdonisJS](h
 npm install --save adminjs-adonis adminjs@^6.0.0
 
 # or using yarn:
-yarn add adminjs-adonis adminjs@6.8.7
+yarn add adminjs-adonis adminjs@^6.0.0
 ```
 
 After this, run:


### PR DESCRIPTION
Since v7 of adminjs only ESM is supported, so when installing adminjs for this repo people should be pinning the version to v6.