### PR TITLE
Feature: Virtual filters, search and actions implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,242 @@ export class User extends BaseModel {
 }
 
 ```
+
+### Resource Options
+
+`config/adminjs.ts`'s `adminjs.resources` array is the standard AdminJS way to pass
+per-resource `options` (`filterProperties`, `properties`, `actions`, etc. - see
+[AdminJS's `ResourceOptions`](https://docs.adminjs.co/basics/resource#resourceoptions)),
+but it requires you to opt out of this package's automatic model discovery
+(`adapter.models`) and list every resource by hand.
+
+As a shortcut, you can instead declare a static `$adminResourceOptions` field
+directly on the model - it's merged into that resource's options automatically,
+alongside anything registered via `@adminAction`, while every other model
+still goes through normal auto-discovery:
+
+```ts
+// User.ts
+import { AdminResourceOptions } from '@ioc:Adonis/Addons/AdminJS'
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export class User extends BaseModel {
+    @column({ isPrimary: true })
+    public id: number
+
+    @column()
+    public username: string
+
+    public static $adminResourceOptions: AdminResourceOptions = {
+        // only show these fields in the filter sidebar
+        filterProperties: ['id', 'username'],
+    }
+}
+```
+
+This is the mechanism the sections below (virtual filters & the generic search
+box) rely on to surface a non-column field in the UI.
+
+> **Type it as `AdminResourceOptions` from `@ioc:Adonis/Addons/AdminJS`, not
+> `Partial<ResourceOptions>` from `adminjs` directly.** This package's own
+> `adminjs` devDependency and your app's installed `adminjs` are two separate
+> copies (this matters especially in local dev via `yarn/npm link`), so if
+> your app's version differs even slightly from this package's, TypeScript
+> will see two structurally different `ResourceOptions` types and fail with a
+> confusing error. `AdminResourceOptions` is a small, hand-written type
+> covering just the fields this package merges in - it doesn't depend on
+> whichever `adminjs` version either side happens to have installed. The same
+> applies to `@adminAction`'s options (`ActionDecoratorOptions`, also
+> hand-written for the same reason).
+
+### Filtering
+
+By default, filtering works out of the box for every `@column` - text columns
+get an exact-match filter, except columns marked `unique: true` (eg. via
+`@adminColumn({ unique: true })`, or your primary key) which get a partial
+(`LIKE`) match instead.
+
+#### Virtual & cross-table filters (`@adminFilter`)
+
+Sometimes the value you want to filter by isn't a column on the resource
+itself - eg. it lives on a related table, or needs to be computed. Use the
+`@adminFilter` decorator to register a static resolver method as a virtual
+filter:
+
+```ts
+// User.ts
+import { adminFilter } from '@ioc:Adonis/Addons/AdminJS'
+import {
+    BaseModel,
+    ModelQueryBuilderContract,
+    column,
+} from '@ioc:Adonis/Lucid/Orm'
+
+import Profile from './Profile'
+
+export class User extends BaseModel {
+    @column({ isPrimary: true })
+    public id: number
+
+    @column()
+    public profileId: number
+
+    // registers a filter available under the "phoneNumber" path
+    @adminFilter('phoneNumber', { type: 'string' })
+    public static async filterByPhoneNumber(value: string) {
+        const profiles = await Profile.query()
+            .whereLike('phoneNumber', `%${value}%`)
+            .select('id')
+
+        // do any async work first, then return a *synchronous* callback that
+        // mutates the query - see "Why does the resolver return a function?"
+        // below for why this two-step shape matters.
+        return (query: ModelQueryBuilderContract<typeof User>) => {
+            query.whereIn(
+                'profileId',
+                profiles.map((profile) => profile.id)
+            )
+        }
+    }
+}
+```
+
+A virtual filter's path (`'phoneNumber'` above) doesn't correspond to a real
+column, so AdminJS won't show it in the filter sidebar automatically - it needs
+an entry in `properties` before it'll appear (AdminJS only creates a virtual UI
+property for paths that show up there), added via
+[`$adminResourceOptions`](#resource-options):
+
+```ts
+public static $adminResourceOptions: AdminResourceOptions = {
+    properties: {
+        // scope it to the filter view only - it isn't a real field, so it
+        // shouldn't try to render on the list/show/edit pages
+        phoneNumber: {
+            isVisible: { filter: true, list: false, show: false, edit: false },
+        },
+    },
+}
+```
+
+> **Don't reach for `filterProperties` to do this.** A non-empty
+> `filterProperties` array replaces AdminJS's default ("every visible column is
+> filterable") behaviour entirely - you'd have to enumerate every other column
+> you still want filterable, and it's easy to silently drop one. Scoping the
+> new virtual property with `isVisible` (as above) leaves every real column's
+> default filter behaviour untouched.
+
+AdminJS labels a property from its path (`phoneNumber` → "Phone Number") unless
+you configure a translation for it via the top-level `locale.translations`
+option in `config/adminjs.ts` - see
+[AdminJS's i18n docs](https://docs.adminjs.co/basics/internationalization) if
+you need a custom label. Note that `PropertyOptions` (the type of each entry
+in `properties`) has no `label` field itself.
+
+**Why does the resolver return a function?** Lucid/Knex query builder
+callbacks (`query.where((builder) => { ... })`) must be synchronous. A
+resolver that needs to `await` something (like the `Profile` lookup above)
+can't do that work inside such a callback. Instead, `@adminFilter` resolvers
+run their async work up front and return a plain synchronous callback with the
+result baked in, which the adapter then applies to the query.
+
+#### Generic search box
+
+Mark one or more columns `searchable: true` via `@adminColumn` to have them
+participate in a generic, OR-combined search filter, available under the
+reserved path `'search'` (exported as `SEARCH_PROPERTY_PATH`):
+
+```ts
+// User.ts
+import {
+    AdminResourceOptions,
+    SEARCH_PROPERTY_PATH,
+    adminColumn,
+} from '@ioc:Adonis/Addons/AdminJS'
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export class User extends BaseModel {
+    @column({ isPrimary: true })
+    public id: number
+
+    @column()
+    @adminColumn({ searchable: true })
+    public username: string
+
+    public static $adminResourceOptions: AdminResourceOptions = {
+        properties: {
+            [SEARCH_PROPERTY_PATH]: {
+                isVisible: { filter: true, list: false, show: false, edit: false },
+            },
+        },
+    }
+}
+```
+
+Typing a value into the resulting **Search** filter runs a `LIKE` match
+against every `searchable` column and OR-combines the results.
+
+Virtual filters (see above) can join the same search box by adding
+`includeInSearch: true`:
+
+```ts
+@adminFilter('phoneNumber', { type: 'string', includeInSearch: true })
+public static async filterByPhoneNumber(value: string) {
+    // ...same as before
+}
+```
+
+Now the generic search box also searches phone numbers via the related
+`Profile` table, alongside any `searchable` columns - no extra wiring needed.
+
+### Custom Actions (`@adminAction`)
+
+Use `@adminAction` to register a custom AdminJS action (resource, record, or
+bulk - see [AdminJS's Actions docs](https://docs.adminjs.co/basics/action))
+directly on the model, Django-admin style. The decorated static method becomes
+the action's `handler` and is wired into that resource automatically - no
+changes needed in `config/adminjs.ts`.
+
+```ts
+// User.ts
+import { adminAction } from '@ioc:Adonis/Addons/AdminJS'
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export class User extends BaseModel {
+    @column({ isPrimary: true })
+    public id: number
+
+    @column()
+    public isActive: boolean
+
+    // a record action: shows up as a button on a single User's show/list page
+    @adminAction('deactivate', {
+        actionType: 'record',
+        icon: 'Stop',
+        guard: 'sureToDeactivate',
+    })
+    public static async deactivate(request, response, context) {
+        const user = await User.findOrFail(context.record?.id())
+
+        user.isActive = false
+        await user.save()
+
+        return {
+            record: context.record?.toJSON(context.currentAdmin),
+            notice: { message: 'User deactivated', type: 'success' },
+        }
+    }
+}
+```
+
+The second argument to `@adminAction` (`actionType` required; `icon`, `guard`,
+`component`, `isVisible`, `isAccessible`, `showInDrawer`, etc. optional) is a
+small, hand-written type (`ActionDecoratorOptions`) rather than AdminJS's own
+`Action` interface imported directly - see the
+[note on `AdminResourceOptions`](#resource-options) above for why. Any other
+AdminJS `Action` field (eg. `before`, `after`, `variant`) can still be passed
+through - the type has an index signature for that - it just isn't individually
+documented here. See
+[here](./adonis-typings/adapter/decorator.ts#ActionDecoratorOptions) for the
+explicitly-typed fields, or [AdminJS's own docs](https://docs.adminjs.co/basics/action)
+for the full list of what AdminJS itself supports.

--- a/README.md
+++ b/README.md
@@ -178,10 +178,11 @@ box) rely on to surface a non-column field in the UI.
 
 ### Filtering
 
-By default, filtering works out of the box for every `@column` - text columns
-get an exact-match filter, except columns marked `unique: true` (eg. via
-`@adminColumn({ unique: true })`, or your primary key) which get a partial
-(`LIKE`) match instead.
+By default, filtering works out of the box for every `@column` - most columns
+get an exact-match filter, except **string-typed** columns marked `unique: true`
+(eg. via `@adminColumn({ unique: true })`, or a string primary key) which get a
+partial (`LIKE`) match instead. A numeric primary key (the common case) still
+gets an exact match, since the `LIKE` behavior only kicks in for string values.
 
 #### Virtual & cross-table filters (`@adminFilter`)
 
@@ -266,6 +267,15 @@ resolver that needs to `await` something (like the `Profile` lookup above)
 can't do that work inside such a callback. Instead, `@adminFilter` resolvers
 run their async work up front and return a plain synchronous callback with the
 result baked in, which the adapter then applies to the query.
+
+> **A resolver declared with `type: 'date'` or `type: 'datetime'` receives a
+> `{ from, to }` range object instead of a string.** AdminJS submits those
+> filter types as a from/to range (its built-in date-range picker), so a
+> resolver backing one must branch on the value's shape - eg.
+> `typeof value === 'string' ? ... : query.whereBetween(..., [value.from, value.to])`.
+> Every other filter type always receives a plain string, including when the
+> filter is triggered via the generic search box below (its text input can
+> only ever submit a string).
 
 #### Generic search box
 

--- a/adonis-typings/adapter/Resource.ts
+++ b/adonis-typings/adapter/Resource.ts
@@ -1,5 +1,5 @@
 declare module '@ioc:Adonis/Addons/AdminJS' {
-    import { BaseResource, Filter, ParamsType } from 'adminjs'
+    import { BaseProperty, BaseResource, Filter, ParamsType } from 'adminjs'
     import type {
         LucidModel,
         ModelQueryBuilderContract,
@@ -21,17 +21,21 @@ declare module '@ioc:Adonis/Addons/AdminJS' {
         public properties(): Property[]
 
         /**
-         * Helper to get property for the given column
+         * Helper to get property for the given column, or a synthetic
+         * {@link BaseProperty} for the reserved search path / a registered
+         * virtual filter path
          */
-        public property(path: string): Property | null
+        public property(path: string): Property | BaseProperty | null
 
         /**
-         * Helper to apply filters on a given query
+         * Helper to apply filters (including virtual filters & the generic
+         * search) on a given query. Mutates `query` in place; doesn't return
+         * it, since Lucid query builders are themselves thenable.
          */
         public applyFilter(
             query: ModelQueryBuilderContract<LucidModel>,
             filter: Filter
-        ): ModelQueryBuilderContract<LucidModel>
+        ): Promise<void>
 
         /**
          * Returns number of objects matching the given filter

--- a/adonis-typings/adapter/decorator.ts
+++ b/adonis-typings/adapter/decorator.ts
@@ -41,6 +41,11 @@ declare module '@ioc:Adonis/Addons/AdminJS' {
          */
         sortable: boolean
         /**
+         * Whether field participates in the generic multi-column search
+         * (see {@link SEARCH_PROPERTY_PATH}). Defaults to false
+         */
+        searchable: boolean
+        /**
          * Whether field is optional or not. Defaults to false
          */
         optional: boolean
@@ -154,4 +159,214 @@ declare module '@ioc:Adonis/Addons/AdminJS' {
      * Runs after the original 'beforeCreate' hook of AdonisJS
      */
     export const afterFetch: HookDecorator<LucidRow[]>
+
+    /**
+     * Reserved filter path for the generic, multi-column search box.
+     * Any column decorated with `@adminColumn({ searchable: true })`, and any
+     * `@adminFilter` marked `includeInSearch: true`, is OR'd together when this
+     * path is submitted as a filter.
+     */
+    export const SEARCH_PROPERTY_PATH: 'search'
+
+    /**
+     * Options for a virtual (non-column) filter registered via {@link adminFilter}
+     */
+    export type AdminFilterOptions = {
+        /**
+         * Type of value this filter accepts. Defaults to 'string'
+         */
+        type?: PropertyType
+        /**
+         * Whether this filter should also be OR'd into the generic multi-column
+         * search box registered at {@link SEARCH_PROPERTY_PATH}. Defaults to false
+         */
+        includeInSearch?: boolean
+    }
+
+    /**
+     * A resolver for a virtual filter. Receives the raw filter value and must
+     * resolve any async work (eg. querying other tables) up front, returning a
+     * synchronous callback that mutates the query builder it's given.
+     *
+     * The callback is invoked either directly (when the filter is used on its
+     * own) or nested inside an `orWhere` group (when it's included in the
+     * generic search), so it must not assume it's the only condition applied.
+     */
+    export type FilterResolver = (
+        value: string
+    ) => Promise<(builder: ModelQueryBuilderContract<LucidModel>) => void>
+
+    /**
+     * Type for the decorator providing virtual filter functionality
+     */
+    export type FilterDecorator = (
+        path: string,
+        options?: AdminFilterOptions
+    ) => <
+        Property extends string,
+        T extends LucidModel & Record<Property, FilterResolver>
+    >(
+        target: T,
+        property: Property
+    ) => void
+
+    /**
+     * Registers a static method as a virtual (non-column) filter for this model,
+     * available under the given path in the AdminJS filter drawer.
+     *
+     * Runs when a filter/search request includes a value for `path`.
+     */
+    export const adminFilter: FilterDecorator
+
+    /**
+     * Options for a custom admin action registered via {@link adminAction}.
+     *
+     * Hand-written rather than imported from AdminJS's own `Action` interface,
+     * so that a consuming app doesn't need the exact same `adminjs` version
+     * installed as this package's own dependency to satisfy the type checker -
+     * AdminProvider merges this into AdminJS's real `Action` type internally,
+     * where version differences don't cross a package boundary. Mirrors the
+     * commonly used subset of AdminJS's options; see
+     * https://docs.adminjs.co/basics/action for the full list AdminJS itself
+     * supports (anything not listed here can still be passed through - see
+     * the index signature below).
+     */
+    export type ActionDecoratorOptions = {
+        /**
+         * Type of action - 'resource' (whole resource), 'record' (single row),
+         * or 'bulk' (multiple selected rows)
+         */
+        actionType: 'resource' | 'record' | 'bulk'
+        /**
+         * Icon name for the action button
+         */
+        icon?: string
+        /**
+         * Guard message - user has to confirm this before the action runs
+         */
+        guard?: string
+        /**
+         * Component used to render the action. `false` means no dedicated
+         * view - the action runs immediately when clicked
+         */
+        component?: string | false
+        /**
+         * Whether the action is visible - boolean, or a function receiving
+         * the AdminJS action context
+         */
+        isVisible?: boolean | ((context: any) => boolean)
+        /**
+         * Whether the action can be invoked - boolean, or a function
+         * receiving the AdminJS action context
+         */
+        isAccessible?: boolean | ((context: any) => boolean)
+        /**
+         * Whether the action should open in a drawer instead of a full page.
+         * Defaults to false
+         */
+        showInDrawer?: boolean
+        /**
+         * Any other AdminJS `Action` option (eg. `variant`, `containerWidth`,
+         * `layout`, `before`, `after`) - passed through as-is
+         */
+        [key: string]: any
+    }
+
+    /**
+     * Handler signature for a custom admin action - matches AdminJS's own
+     * `ActionHandler` shape structurally, without importing it.
+     */
+    export type ActionDecoratorHandler = (
+        request: any,
+        response: any,
+        context: any
+    ) => Promise<any>
+
+    /**
+     * Type for the decorator providing custom admin action functionality
+     */
+    export type ActionDecorator = (
+        name: string,
+        options: ActionDecoratorOptions
+    ) => <
+        Property extends string,
+        T extends LucidModel & Record<Property, ActionDecoratorHandler>
+    >(
+        target: T,
+        property: Property
+    ) => void
+
+    /**
+     * Registers a static method as a custom AdminJS action (resource, record or
+     * bulk) for this model. The decorated method becomes the action's handler
+     * and is automatically wired into the resource's `options.actions` - no
+     * manual config-file changes needed.
+     */
+    export const adminAction: ActionDecorator
+
+    /**
+     * A minimal, adminjs-version-independent subset of AdminJS's own
+     * `ResourceOptions`, for the fields {@link AdminProvider} merges in
+     * automatically via a model's static `$adminResourceOptions`.
+     *
+     * Hand-written rather than imported from `adminjs` for the same reason as
+     * {@link ActionDecoratorOptions} above - see
+     * https://docs.adminjs.co/basics/resource#resourceoptions for the full
+     * list of options AdminJS itself supports (anything not listed here can
+     * still be passed through - see the index signature below).
+     */
+    export type AdminResourceOptions = {
+        /**
+         * Paths (real columns, or virtual `@adminFilter`/search paths) which
+         * should be visible in the filter drawer. Prefer scoping a virtual
+         * path via its own `properties.<path>.isVisible.filter` (see below)
+         * over setting this - a non-empty `filterProperties` replaces every
+         * column's default filter visibility, not just adds to it.
+         */
+        filterProperties?: string[]
+        /**
+         * Paths which should be visible on the list view
+         */
+        listProperties?: string[]
+        /**
+         * Paths which should be visible on the edit view
+         */
+        editProperties?: string[]
+        /**
+         * Paths which should be visible on the show view
+         */
+        showProperties?: string[]
+        /**
+         * Per-property configuration, keyed by path. An entry (even an empty
+         * one) is required for any virtual `@adminFilter`/search path to
+         * appear in the UI at all - see the "Filtering" section of the README
+         */
+        properties?: Record<
+            string,
+            {
+                isVisible?:
+                    | boolean
+                    | {
+                          list?: boolean
+                          show?: boolean
+                          edit?: boolean
+                          filter?: boolean
+                      }
+                [key: string]: any
+            }
+        >
+        /**
+         * Custom actions - usually populated automatically from
+         * `@adminAction`, but can be extended here too
+         */
+        actions?: Record<
+            string,
+            ActionDecoratorOptions & { handler?: ActionDecoratorHandler }
+        >
+        /**
+         * Any other AdminJS `ResourceOptions` field (eg. `navigation`, `sort`,
+         * `id`) - passed through as-is
+         */
+        [key: string]: any
+    }
 }

--- a/adonis-typings/adapter/decorator.ts
+++ b/adonis-typings/adapter/decorator.ts
@@ -188,12 +188,19 @@ declare module '@ioc:Adonis/Addons/AdminJS' {
      * resolve any async work (eg. querying other tables) up front, returning a
      * synchronous callback that mutates the query builder it's given.
      *
+     * The value is a plain string for most filter types, but AdminJS submits
+     * `date`/`datetime` filters as a `{ from, to }` range instead (see its
+     * `DefaultDatetimeFilterProperty` component) - a resolver backing a filter
+     * declared with one of those types must handle both shapes. When the
+     * filter is used via the generic search box, the value is always a plain
+     * string (the search box's own text input can't submit a range).
+     *
      * The callback is invoked either directly (when the filter is used on its
      * own) or nested inside an `orWhere` group (when it's included in the
      * generic search), so it must not assume it's the only condition applied.
      */
     export type FilterResolver = (
-        value: string
+        value: string | { from: string; to: string }
     ) => Promise<(builder: ModelQueryBuilderContract<LucidModel>) => void>
 
     /**

--- a/adonis-typings/orm.ts
+++ b/adonis-typings/orm.ts
@@ -1,7 +1,35 @@
 declare module '@ioc:Adonis/Lucid/Orm' {
-    import { AdminColumnOptions } from '@ioc:Adonis/Addons/AdminJS'
+    import {
+        AdminColumnOptions,
+        AdminFilterOptions,
+        AdminResourceOptions,
+        ActionDecoratorHandler,
+        ActionDecoratorOptions,
+        FilterResolver,
+    } from '@ioc:Adonis/Addons/AdminJS'
 
     export interface LucidModel {
         $adminColumnOptions?: Record<string, Partial<AdminColumnOptions>>
+        $adminFilters?: Record<
+            string,
+            AdminFilterOptions & { resolve: FilterResolver }
+        >
+        $adminActions?: Record<
+            string,
+            ActionDecoratorOptions & {
+                name: string
+                handler: ActionDecoratorHandler
+            }
+        >
+        /**
+         * Escape hatch for resourceOptions (eg. `filterProperties`, `properties`)
+         * that aren't driven by a per-column/per-action decorator. Merged into
+         * this model's resource options by `AdminProvider`.
+         *
+         * Deliberately typed with this package's own (adminjs-version-independent)
+         * {@link AdminResourceOptions} rather than AdminJS's own `ResourceOptions` -
+         * see the comment on `AdminResourceOptions` for why.
+         */
+        $adminResourceOptions?: AdminResourceOptions
     }
 }

--- a/providers/AdminProvider.ts
+++ b/providers/AdminProvider.ts
@@ -85,7 +85,17 @@ export default class AdminProvider {
                     )()
 
                     if (!options.resources) {
-                        options.resources = models
+                        options.resources = models.map((model) => ({
+                            resource: model,
+                            options: {
+                                ...(model.$adminResourceOptions || {}),
+                                actions: {
+                                    ...(model.$adminResourceOptions?.actions ||
+                                        {}),
+                                    ...(model.$adminActions || {}),
+                                },
+                            },
+                        }))
                     } else if (config.adapter.models) {
                         throw new Error(
                             `You cannot pass both 'adapter.models' and 'adminjs.resources'`

--- a/src/Adapter/BaseResource.ts
+++ b/src/Adapter/BaseResource.ts
@@ -139,6 +139,56 @@ export class BaseResource extends BaseAdminResource {
         for (const key of Object.keys(filter.filters)) {
             const filterElement = filter.filters[key]
 
+            // A real column's filter always wins over the reserved search path
+            // or a virtual filter that happens to share its path - this mirrors
+            // property()'s own column-first precedence, so a column named eg.
+            // "search", or an `@adminFilter` registered under an existing
+            // column's path, doesn't get silently shadowed at query time.
+            if (filterElement.property instanceof Property) {
+                const property = filterElement.property
+
+                if (typeof filterElement.value === 'string') {
+                    if (
+                        property.type() === 'uuid' &&
+                        !Validator.isUUID(filterElement.value)
+                    ) {
+                        continue
+                    }
+
+                    if (property.columnOptions.enum) {
+                        let enumValue: string | number
+
+                        try {
+                            enumValue = getEnumValue(
+                                property.columnOptions.enum,
+                                filterElement.value
+                            )
+                        } catch {
+                            // malformed/stale filter value that doesn't match
+                            // any enum key or value - skip it rather than
+                            // 500ing the whole list/count request
+                            continue
+                        }
+
+                        query.where(key, enumValue)
+                    } else if (
+                        property.isId() &&
+                        property.type() === 'string'
+                    ) {
+                        query.whereLike(key, `%${filterElement.value}%`)
+                    } else {
+                        query.where(key, filterElement.value)
+                    }
+                } else {
+                    query.whereBetween(key, [
+                        filterElement.value.from,
+                        filterElement.value.to,
+                    ])
+                }
+
+                continue
+            }
+
             if (key === SEARCH_PROPERTY_PATH) {
                 await this.applySearch(query, String(filterElement.value))
                 continue
@@ -148,40 +198,9 @@ export class BaseResource extends BaseAdminResource {
 
             if (virtualFilter) {
                 const applyWhere = await virtualFilter.resolve(
-                    String(filterElement.value)
+                    filterElement.value
                 )
                 query.where(applyWhere)
-                continue
-            }
-
-            const property = filterElement.property as Property
-
-            if (typeof filterElement.value === 'string') {
-                if (
-                    property.type() === 'uuid' &&
-                    !Validator.isUUID(filterElement.value)
-                ) {
-                    continue
-                }
-
-                if (property.columnOptions.enum) {
-                    query.where(
-                        key,
-                        getEnumValue(
-                            property.columnOptions.enum,
-                            filterElement.value
-                        )
-                    )
-                } else if (property.isId() && property.type() === 'string') {
-                    query.whereLike(key, `%${filterElement.value}%`)
-                } else {
-                    query.where(key, filterElement.value)
-                }
-            } else {
-                query.whereBetween(key, [
-                    filterElement.value.from,
-                    filterElement.value.to,
-                ])
             }
         }
     }
@@ -394,11 +413,19 @@ export class BaseResource extends BaseAdminResource {
                     property.isAttachment &&
                     typeof params[property.path()] === 'string'
                 ) {
-                    if (!params[property.path()]) {
-                        unchangedAttachments[property.path()] = null
-                    }
+                    const isCleared = !params[property.path()]
 
-                    return acc
+                    // Clearing a *required* attachment isn't "leave it
+                    // untouched" - it's removing a mandatory value, so it must
+                    // still go through file validation (which rejects the
+                    // empty string) instead of silently saving `null`.
+                    if (!isCleared || !property.isRequired()) {
+                        if (isCleared) {
+                            unchangedAttachments[property.path()] = null
+                        }
+
+                        return acc
+                    }
                 }
 
                 acc[property.path()] = property.getSchemaType()

--- a/src/Adapter/BaseResource.ts
+++ b/src/Adapter/BaseResource.ts
@@ -1,6 +1,7 @@
 import { getEnumValue } from '../helpers'
 import { inject } from '@adonisjs/core/build/standalone'
 import {
+    BaseProperty,
     BaseResource as BaseAdminResource,
     ErrorTypeEnum,
     Filter,
@@ -22,6 +23,10 @@ import type {
 import { components } from './Components'
 import { Property } from './Property'
 import { LucidRecord } from './Record'
+import { SEARCH_PROPERTY_PATH } from './decorators'
+import { getAdminColumnOptions } from './helpers'
+
+type WhereClause = (builder: ModelQueryBuilderContract<LucidModel>) => void
 
 /**
  * Resource adapter for AdminJS
@@ -84,43 +89,90 @@ export class BaseResource extends BaseAdminResource {
         const properties: Property[] = []
 
         for (const column of this.model.$columnsDefinitions.keys()) {
-            properties.push(this.property(column)!)
+            // property() always returns a real Property for column paths
+            properties.push(this.property(column) as Property)
         }
 
         return properties
     }
 
     /**
-     * Helper to get property for the given column
+     * Helper to get property for the given column, the reserved generic
+     * search path, or a registered virtual filter path
      */
     public property(path: string) {
-        if (!this.model.$columnsDefinitions.has(path)) {
-            return null
+        if (this.model.$columnsDefinitions.has(path)) {
+            return new Property(this.model, path, this.validator)
         }
 
-        return new Property(this.model, path, this.validator)
+        if (path === SEARCH_PROPERTY_PATH) {
+            return new BaseProperty({ path, type: 'string', isSortable: false })
+        }
+
+        const filterOptions = this.model.$adminFilters?.[path]
+
+        if (filterOptions) {
+            return new BaseProperty({
+                path,
+                type: filterOptions.type || 'string',
+                isSortable: false,
+            })
+        }
+
+        return null
     }
 
     /**
-     * Helper to apply filters on a given query
+     * Helper to apply filters (including the reserved search path & any
+     * registered virtual filters) on a given query.
+     *
+     * Mutates `query` in place and doesn't return it: Lucid query builders are
+     * themselves thenable (awaiting one executes the query), so this being an
+     * `async` function must never `return query` - doing so would make the
+     * promise-resolution algorithm call `query.then()` to unwrap it, executing
+     * the query before callers get to add `.limit()`/`.offset()`/`.orderBy()`.
      */
-    public applyFilter(
+    public async applyFilter(
         query: ModelQueryBuilderContract<LucidModel>,
         filter: Filter
-    ) {
-        Object.keys(filter.filters).forEach((key) => {
+    ): Promise<void> {
+        for (const key of Object.keys(filter.filters)) {
             const filterElement = filter.filters[key]
-            const property = filterElement.property
+
+            if (key === SEARCH_PROPERTY_PATH) {
+                await this.applySearch(query, String(filterElement.value))
+                continue
+            }
+
+            const virtualFilter = this.model.$adminFilters?.[key]
+
+            if (virtualFilter) {
+                const applyWhere = await virtualFilter.resolve(
+                    String(filterElement.value)
+                )
+                query.where(applyWhere)
+                continue
+            }
+
+            const property = filterElement.property as Property
 
             if (typeof filterElement.value === 'string') {
                 if (
                     property.type() === 'uuid' &&
                     !Validator.isUUID(filterElement.value)
                 ) {
-                    return
+                    continue
                 }
 
-                if (property.isId() && property.type() === 'string') {
+                if (property.columnOptions.enum) {
+                    query.where(
+                        key,
+                        getEnumValue(
+                            property.columnOptions.enum,
+                            filterElement.value
+                        )
+                    )
+                } else if (property.isId() && property.type() === 'string') {
                     query.whereLike(key, `%${filterElement.value}%`)
                 } else {
                     query.where(key, filterElement.value)
@@ -131,16 +183,65 @@ export class BaseResource extends BaseAdminResource {
                     filterElement.value.to,
                 ])
             }
-        })
+        }
+    }
 
-        return query
+    /**
+     * Helper to apply the generic multi-column search (see
+     * {@link SEARCH_PROPERTY_PATH}) on a given query.
+     *
+     * OR-combines a `whereLike` for every column marked `searchable: true`
+     * with every registered virtual filter marked `includeInSearch: true`.
+     * Each virtual filter's async work is resolved up front so the final
+     * combination only needs a synchronous query builder callback.
+     */
+    private async applySearch(
+        query: ModelQueryBuilderContract<LucidModel>,
+        value: string
+    ) {
+        if (!value) {
+            return
+        }
+
+        const like = `%${value}%`
+        const wheres: WhereClause[] = []
+
+        for (const column of this.model.$columnsDefinitions.keys()) {
+            if (getAdminColumnOptions(this.model, column).searchable) {
+                wheres.push((builder) => builder.orWhereLike(column, like))
+            }
+        }
+
+        for (const filterOptions of Object.values(
+            this.model.$adminFilters || {}
+        )) {
+            if (filterOptions.includeInSearch) {
+                wheres.push(await filterOptions.resolve(value))
+            }
+        }
+
+        if (!wheres.length) {
+            return
+        }
+
+        query.where((builder) => {
+            wheres.forEach((applyWhere, index) => {
+                if (index === 0) {
+                    builder.where(applyWhere)
+                } else {
+                    builder.orWhere(applyWhere)
+                }
+            })
+        })
     }
 
     /**
      * Returns number of objects matching the given filter
      */
     public async count(filter: Filter) {
-        const query = this.applyFilter(this.model.query(), filter)
+        const query = this.model.query()
+
+        await this.applyFilter(query, filter)
 
         const obj = await query.count('*', 'count').firstOrFail()
 
@@ -163,7 +264,9 @@ export class BaseResource extends BaseAdminResource {
                 | undefined
         }
     ): Promise<LucidRecord[]> {
-        const query = this.applyFilter(this.model.query(), filter)
+        const query = this.model.query()
+
+        await this.applyFilter(query, filter)
 
         if (options.limit !== undefined) {
             query.limit(options.limit)
@@ -248,7 +351,15 @@ export class BaseResource extends BaseAdminResource {
                 continue
             }
 
-            data[property.path()] = await property.serialize(row)
+            try {
+                data[property.path()] = await property.serialize(row)
+            } catch (error) {
+                error.message = `Failed to serialize property "${property.path()}" on resource "${this.id()}": ${
+                    error.message
+                }`
+
+                throw error
+            }
         }
 
         return data
@@ -264,18 +375,34 @@ export class BaseResource extends BaseAdminResource {
     /**
      * Helper to validate params passed during creation / updation.
      *
-     * TODO: add support for files
      * TODO: add support for JSON
      */
     public async validateParams(params: ParamsType) {
         const propertyHash: Record<string, Property> = {}
+        // A string value for an attachment property means no new file was
+        // uploaded (it's either the existing url or an empty string when the
+        // input was cleared) so it shouldn't go through file validation.
+        const unchangedAttachments: Record<string, null> = {}
 
         const validatorSchema = this.validator.schema.create(
             this.properties().reduce((acc, property) => {
-                if (property.isEditable()) {
-                    acc[property.path()] = property.getSchemaType()
-                    propertyHash[property.path()] = property
+                if (!property.isEditable()) {
+                    return acc
                 }
+
+                if (
+                    property.isAttachment &&
+                    typeof params[property.path()] === 'string'
+                ) {
+                    if (!params[property.path()]) {
+                        unchangedAttachments[property.path()] = null
+                    }
+
+                    return acc
+                }
+
+                acc[property.path()] = property.getSchemaType()
+                propertyHash[property.path()] = property
 
                 return acc
             }, {} as TypedSchema)
@@ -297,7 +424,7 @@ export class BaseResource extends BaseAdminResource {
                 }
             })
 
-            return data
+            return { ...data, ...unchangedAttachments }
         } catch (error) {
             if (error instanceof this.validator.ValidationException) {
                 // build AdminJS validation error from Adonis' ValidationException

--- a/src/Adapter/Property.ts
+++ b/src/Adapter/Property.ts
@@ -166,6 +166,8 @@ export class Property extends BaseProperty {
      * Helper to compute reference relation for this property.
      */
     private getReference() {
+        const matches: BelongsToRelationContract<LucidModel, LucidModel>[] = []
+
         for (const relation of this.model.$relationsDefinitions.values()) {
             if (!relation.booted) {
                 relation.boot()
@@ -175,13 +177,23 @@ export class Property extends BaseProperty {
                 relation.type === 'belongsTo' &&
                 relation.foreignKey === this.columnKey
             ) {
-                this.relation = relation
-
-                return relation.relatedModel().table
+                matches.push(relation)
             }
         }
 
-        return null
+        // If more than one belongsTo relation shares this foreign key (eg. a
+        // polymorphic column resolved to a different table per row depending on
+        // some discriminator), we can't know which one applies to any given row.
+        // AdminJS can only resolve a reference to a single resource for the whole
+        // property, so guessing (eg. always picking the first) would silently
+        // point at the wrong table for every row that isn't that first type.
+        if (matches.length !== 1) {
+            return null
+        }
+
+        this.relation = matches[0]
+
+        return this.relation.relatedModel().table
     }
 
     /**
@@ -293,7 +305,7 @@ export class Property extends BaseProperty {
         }
 
         if (this.isAttachment) {
-            return value.url
+            return typeof value === 'string' ? value : value.url
         }
 
         return value

--- a/src/Adapter/decorators.ts
+++ b/src/Adapter/decorators.ts
@@ -1,5 +1,7 @@
 import type {
+    ActionDecorator,
     AdminColumnOptions,
+    FilterDecorator,
     HookDecorator,
 } from '@ioc:Adonis/Addons/AdminJS'
 import type {
@@ -20,6 +22,47 @@ export function adminColumn(options: Partial<AdminColumnOptions>) {
         model.$adminColumnOptions![property] = options
     }
 }
+
+/**
+ * Reserved filter path for the generic, multi-column search box.
+ */
+export const SEARCH_PROPERTY_PATH = 'search'
+
+/**
+ * Registers a static method as a virtual (non-column) filter, available under
+ * the given path in the AdminJS filter drawer.
+ */
+export const adminFilter: FilterDecorator = (path, options = {}) =>
+    function (target, property) {
+        target.boot()
+
+        const model = target as unknown as LucidModel
+
+        model.$defineProperty('$adminFilters', {}, 'inherit')
+        model.$adminFilters![path] = {
+            ...options,
+            resolve: target[property].bind(target),
+        }
+    }
+
+/**
+ * Registers a static method as a custom AdminJS action (resource, record or
+ * bulk) for this model, automatically wired into the resource's
+ * `options.actions` by {@link AdminProvider}.
+ */
+export const adminAction: ActionDecorator = (name, options) =>
+    function (target, property) {
+        target.boot()
+
+        const model = target as unknown as LucidModel
+
+        model.$defineProperty('$adminActions', {}, 'inherit')
+        model.$adminActions![name] = {
+            ...options,
+            name,
+            handler: target[property].bind(target),
+        }
+    }
 
 export const beforeCreate: HookDecorator<LucidRow> = () =>
     function (target, property) {

--- a/src/Adapter/helpers.ts
+++ b/src/Adapter/helpers.ts
@@ -28,6 +28,7 @@ export function getAdminColumnOptions(model: LucidModel, columnKey: string) {
         unique: providedOptions?.unique ?? columnOptions.isPrimary,
         enum: providedOptions?.enum,
         sortable: providedOptions?.sortable || false,
+        searchable: providedOptions?.searchable || false,
         optional:
             providedOptions?.optional ??
             (columnOptions.meta?.autoCreate ||

--- a/src/Plugin/router.ts
+++ b/src/Plugin/router.ts
@@ -14,6 +14,36 @@ export class Router {
     ) {}
 
     /**
+     * Helper to find the currently authenticated admin user.
+     *
+     * `ctx.auth.user` always resolves against the app's *default* auth
+     * guard, which may not be the guard that actually authenticated this
+     * request. If the admin panel is protected via an `auth:<guard>`
+     * middleware (Adonis's convention for naming a specific, non-default
+     * guard), we use that guard explicitly instead of silently falling
+     * back to `undefined`.
+     */
+    private getCurrentAdmin(ctx: HttpContextContract) {
+        const auth = (ctx as any).auth
+
+        if (!auth) {
+            return undefined
+        }
+
+        const authMiddleware = (
+            (this.config.enabled && this.config.middlewares) ||
+            []
+        ).find(
+            (middleware) =>
+                middleware === 'auth' || middleware.startsWith('auth:')
+        )
+
+        const guard = authMiddleware?.split(':')[1]
+
+        return guard ? auth.use(guard).user : auth.user
+    }
+
+    /**
      * Helper function to create handler for a given adminjs route
      */
     public createRouteHandler(route: RouterType['routes'][number]) {
@@ -22,7 +52,7 @@ export class Router {
                 {
                     admin: this.admin,
                 },
-                (ctx as any).auth?.user // if auth plugin is installed then get user from it
+                this.getCurrentAdmin(ctx)
             )
 
             const html = await controller[route.action](

--- a/tests/unit/src/Adapter/BaseResource.spec.ts
+++ b/tests/unit/src/Adapter/BaseResource.spec.ts
@@ -1,5 +1,9 @@
 import { BaseResource } from '../../../../src/Adapter/BaseResource'
 import { LucidRecord } from '../../../../src/Adapter/Record'
+import {
+    adminFilter,
+    SEARCH_PROPERTY_PATH,
+} from '../../../../src/Adapter/decorators'
 import { test } from '@japa/runner'
 import { Filter, ValidationError } from 'adminjs'
 import { DateTime } from 'luxon'
@@ -63,6 +67,65 @@ test.group('Resource | property', (group) => {
         assert.strictEqual(resource.property('abc'), null)
         assert.isFalse(stub.called)
     })
+
+    test('returns a synthetic BaseProperty for the reserved search path', ({
+        assert,
+        application,
+        models,
+    }) => {
+        const resource = application.container.make(BaseResource, [models.User])
+
+        const property = resource.property(SEARCH_PROPERTY_PATH)
+
+        assert.isNotNull(property)
+        assert.notInstanceOf(property, propertyImport.Property)
+        assert.strictEqual(property!.path(), SEARCH_PROPERTY_PATH)
+        assert.strictEqual(property!.type(), 'string')
+        assert.isFalse(property!.isSortable())
+    })
+
+    test('returns a synthetic BaseProperty for a registered virtual filter path', ({
+        assert,
+        application,
+        models,
+    }) => {
+        const UserModel = models.User
+
+        class User extends UserModel {
+            @adminFilter('phoneNumber', { type: 'number' })
+            public static async filterByPhoneNumber() {
+                return () => {}
+            }
+        }
+
+        const resource = application.container.make(BaseResource, [User])
+
+        const property = resource.property('phoneNumber')
+
+        assert.isNotNull(property)
+        assert.notInstanceOf(property, propertyImport.Property)
+        assert.strictEqual(property!.path(), 'phoneNumber')
+        assert.strictEqual(property!.type(), 'number')
+    })
+
+    test('defaults a virtual filter without an explicit type to string', ({
+        assert,
+        application,
+        models,
+    }) => {
+        const UserModel = models.User
+
+        class User extends UserModel {
+            @adminFilter('phoneNumber')
+            public static async filterByPhoneNumber() {
+                return () => {}
+            }
+        }
+
+        const resource = application.container.make(BaseResource, [User])
+
+        assert.strictEqual(resource.property('phoneNumber')!.type(), 'string')
+    })
 })
 
 test.group('Resource | applyFilter', (group) => {
@@ -73,7 +136,7 @@ test.group('Resource | applyFilter', (group) => {
         propertyImport = await import('../../../../src/Adapter/Property')
     })
 
-    test('applies filters correctly to query', ({
+    test('applies filters correctly to query', async ({
         assert,
         application,
         models,
@@ -132,7 +195,7 @@ test.group('Resource | applyFilter', (group) => {
         const whereBetweenStub = sinon.stub(query, 'whereBetween')
         const whereLikeStub = sinon.stub(query, 'whereLike')
 
-        resource.applyFilter(query, filter)
+        await resource.applyFilter(query, filter)
 
         assert.isTrue(whereStub.calledWith('id', '1'))
         assert.isTrue(whereStub.calledWith('username', 'test'))
@@ -146,7 +209,7 @@ test.group('Resource | applyFilter', (group) => {
         assert.isTrue(whereLikeStub.calledOnceWith('email', '%test@test.com%'))
     })
 
-    test('skips filter on uuid when uuid is malformed', ({
+    test('skips filter on uuid when uuid is malformed', async ({
         assert,
         application,
         models,
@@ -205,7 +268,7 @@ test.group('Resource | applyFilter', (group) => {
         const whereBetweenStub = sinon.stub(query, 'whereBetween')
         const whereLikeStub = sinon.stub(query, 'whereLike')
 
-        resource.applyFilter(query, filter)
+        await resource.applyFilter(query, filter)
 
         assert.isTrue(whereStub.calledWith('id', '1'))
         assert.isTrue(whereStub.calledWith('username', 'test'))
@@ -214,6 +277,245 @@ test.group('Resource | applyFilter', (group) => {
             whereBetweenStub.calledOnceWith('createdAt', ['from', 'to'])
         )
         assert.isTrue(whereLikeStub.calledOnceWith('email', '%test@test.com%'))
+    })
+
+    test('converts enum value before applying filter', async ({
+        assert,
+        application,
+        models,
+    }) => {
+        const UserModel = models.User
+        const { column } = application.container.use('Adonis/Lucid/Orm')
+
+        enum UserType {
+            USER = 1,
+            ADMIN = 2,
+        }
+
+        class User extends UserModel {
+            @column()
+            public type: number
+        }
+
+        User.$adminColumnOptions = {
+            type: {
+                enum: UserType,
+            },
+        }
+
+        const resource = application.container.make(BaseResource, [User])
+        const query = models.User.query()
+        const filter = new Filter({ type: 'admin' }, resource)
+
+        const whereStub = sinon.stub(query, 'where')
+
+        await resource.applyFilter(query, filter)
+
+        assert.isTrue(whereStub.calledOnceWith('type', UserType.ADMIN))
+    })
+})
+
+test.group(
+    'Resource | applyFilter | virtual filter (@adminFilter)',
+    (group) => {
+        group.each.teardown(() => sinon.restore())
+
+        test('resolves the virtual filter and applies its where callback', async ({
+            assert,
+            application,
+            models,
+        }) => {
+            const UserModel = models.User
+            const resolve = sinon.stub().resolves(
+                sinon.stub().callsFake((builder) => {
+                    builder.where('username', 'resolved-value')
+                })
+            )
+
+            class User extends UserModel {
+                @adminFilter('phoneNumber')
+                public static async filterByPhoneNumber(value: string) {
+                    return resolve(value)
+                }
+            }
+
+            const resource = application.container.make(BaseResource, [User])
+            const query = User.query()
+            const filter = new Filter({ phoneNumber: '12345' }, resource)
+
+            await resource.applyFilter(query, filter)
+
+            assert.isTrue(resolve.calledOnceWith('12345'))
+            assert.deepEqual(query.toSQL().bindings, ['resolved-value'])
+            assert.include(query.toSQL().sql, '`username` = ?')
+        })
+
+        test('does not treat a virtual filter path as a real column filter', async ({
+            assert,
+            application,
+            models,
+        }) => {
+            const UserModel = models.User
+
+            class User extends UserModel {
+                @adminFilter('phoneNumber')
+                public static async filterByPhoneNumber(value: string) {
+                    return (builder: any) => builder.where('username', value)
+                }
+            }
+
+            const resource = application.container.make(BaseResource, [User])
+            const query = User.query()
+            const whereStub = sinon.stub(query, 'where')
+            const filter = new Filter({ phoneNumber: 'foo' }, resource)
+
+            await resource.applyFilter(query, filter)
+
+            // only the resolved virtual-filter callback should be passed to `where`,
+            // never the raw filter value being applied against a `phoneNumber` column
+            assert.isTrue(whereStub.calledOnce)
+            assert.isFunction(whereStub.firstCall.args[0])
+        })
+    }
+)
+
+test.group('Resource | applyFilter | generic search', (group) => {
+    group.each.teardown(() => sinon.restore())
+
+    test('OR-combines every column marked searchable', async ({
+        assert,
+        application,
+        models,
+    }) => {
+        const UserModel = models.User
+        const { column } = application.container.use('Adonis/Lucid/Orm')
+
+        class User extends UserModel {
+            @column()
+            public email: string
+        }
+
+        User.$adminColumnOptions = {
+            username: { searchable: true },
+            email: { searchable: true },
+        }
+
+        const resource = application.container.make(BaseResource, [User])
+        const query = User.query()
+        const filter = new Filter({ [SEARCH_PROPERTY_PATH]: 'foo' }, resource)
+
+        await resource.applyFilter(query, filter)
+
+        const { sql, bindings } = query.toSQL()
+
+        assert.include(sql, '`username` like ?')
+        assert.include(sql, '`email` like ?')
+        assert.include(sql, ' or ')
+        assert.deepEqual(bindings, ['%foo%', '%foo%'])
+    })
+
+    test('includes a virtual filter marked includeInSearch, ANDed with other active filters', async ({
+        assert,
+        application,
+        models,
+    }) => {
+        const UserModel = models.User
+        const { column } = application.container.use('Adonis/Lucid/Orm')
+
+        class User extends UserModel {
+            @column()
+            public email: string
+
+            @adminFilter('phoneNumber', { includeInSearch: true })
+            public static async filterByPhoneNumber(value: string) {
+                return (builder: any) => builder.where('email', value)
+            }
+        }
+
+        User.$adminColumnOptions = {
+            username: { searchable: true },
+        }
+
+        const resource = application.container.make(BaseResource, [User])
+        const query = User.query()
+        const filter = new Filter(
+            { [SEARCH_PROPERTY_PATH]: 'foo', id: '5' },
+            resource
+        )
+
+        await resource.applyFilter(query, filter)
+
+        const { sql, bindings } = query.toSQL()
+
+        assert.include(sql, '`id` = ?')
+        assert.include(sql, '`username` like ?')
+        assert.include(sql, '`email` = ?')
+        assert.deepEqual(bindings, ['5', '%foo%', 'foo'])
+    })
+
+    test('a virtual filter not marked includeInSearch is left out of the search', async ({
+        assert,
+        application,
+        models,
+    }) => {
+        const UserModel = models.User
+
+        class User extends UserModel {
+            @adminFilter('phoneNumber')
+            public static async filterByPhoneNumber(value: string) {
+                return (builder: any) => builder.where('username', value)
+            }
+        }
+
+        User.$adminColumnOptions = {
+            username: { searchable: true },
+        }
+
+        const resource = application.container.make(BaseResource, [User])
+        const query = User.query()
+        const filter = new Filter({ [SEARCH_PROPERTY_PATH]: 'foo' }, resource)
+
+        await resource.applyFilter(query, filter)
+
+        const { sql, bindings } = query.toSQL()
+
+        assert.include(sql, '`username` like ?')
+        assert.notInclude(sql, 'or')
+        assert.deepEqual(bindings, ['%foo%'])
+    })
+
+    test('applies no where clause when the search value is empty', async ({
+        assert,
+        application,
+        models,
+    }) => {
+        const resource = application.container.make(BaseResource, [models.User])
+        const query = models.User.query()
+        const filter = new Filter({ [SEARCH_PROPERTY_PATH]: '' }, resource)
+
+        await resource.applyFilter(query, filter)
+
+        const { sql, bindings } = query.toSQL()
+
+        assert.notInclude(sql, 'where')
+        assert.deepEqual(bindings, [])
+    })
+
+    test('applies no where clause when there are no searchable columns or virtual filters', async ({
+        assert,
+        application,
+        models,
+    }) => {
+        const resource = application.container.make(BaseResource, [models.User])
+        const query = models.User.query()
+        const filter = new Filter({ [SEARCH_PROPERTY_PATH]: 'foo' }, resource)
+
+        await resource.applyFilter(query, filter)
+
+        const { sql, bindings } = query.toSQL()
+
+        assert.notInclude(sql, 'where')
+        assert.deepEqual(bindings, [])
     })
 })
 
@@ -232,7 +534,7 @@ test.group('Resource | count', (group) => {
 
         const applyFilterStub = sinon
             .stub(resource, 'applyFilter')
-            .returnsArg(0)
+            .returns(Promise.resolve())
         const queryCountStub = sinon
             .stub(ModelQueryBuilder.prototype, 'count')
             .returnsThis()
@@ -271,7 +573,7 @@ test.group('Resource | find', (group) => {
 
         const applyFilterStub = sinon
             .stub(resource, 'applyFilter')
-            .returnsArg(0)
+            .returns(Promise.resolve())
         const limitStub = sinon
             .stub(ModelQueryBuilder.prototype, 'limit')
             .returnsThis()
@@ -325,7 +627,7 @@ test.group('Resource | find', (group) => {
 
         const applyFilterStub = sinon
             .stub(resource, 'applyFilter')
-            .returnsArg(0)
+            .returns(Promise.resolve())
         const limitStub = sinon
             .stub(ModelQueryBuilder.prototype, 'limit')
             .returnsThis()
@@ -508,6 +810,35 @@ test.group('Resource | sanitizeParams', (group) => {
         })
         assert.isTrue(enumStub.calledOnceWith(UserType, 1))
     })
+
+    test('wraps a serialize error with the property path & resource id', async ({
+        assert,
+        application,
+        models,
+    }) => {
+        const UserModel = models.User
+
+        class User extends UserModel {
+            public static $adminColumnOptions = {
+                username: {
+                    serialize: () => {
+                        throw new Error('boom')
+                    },
+                },
+            }
+        }
+
+        const resource = application.container.make(BaseResource, [User])
+
+        try {
+            await resource.sanitizeParams(new User().fill({ id: 1 }))
+            assert.fail('expected sanitizeParams to throw')
+        } catch (error) {
+            assert.include(error.message, 'username')
+            assert.include(error.message, resource.id())
+            assert.include(error.message, 'boom')
+        }
+    })
 })
 
 test.group('Resource | validateParams', (group) => {
@@ -596,6 +927,70 @@ test.group('Resource | validateParams', (group) => {
         } catch (e) {
             assert.instanceOf(e, ValidationError)
         }
+    })
+
+    test('leaves attachment untouched when submitted value is its existing url', async ({
+        assert,
+        application,
+        models,
+    }) => {
+        const UserModel = models.User
+        const { column } = application.container.use('Adonis/Lucid/Orm')
+
+        class User extends UserModel {
+            @column()
+            public attachment: string
+        }
+
+        User.$adminColumnOptions = {
+            attachment: {
+                type: 'file',
+                optional: true,
+            },
+        }
+
+        const resource = application.container.make(BaseResource, [User])
+        const params = {
+            username: 'hello-world',
+            password: 'Hi!',
+            attachment: 'https://example.com/existing-file.pdf',
+        }
+
+        const validatedData = await resource.validateParams(params)
+
+        assert.isFalse('attachment' in validatedData)
+    })
+
+    test('nulls out attachment when submitted value is an empty string', async ({
+        assert,
+        application,
+        models,
+    }) => {
+        const UserModel = models.User
+        const { column } = application.container.use('Adonis/Lucid/Orm')
+
+        class User extends UserModel {
+            @column()
+            public attachment: string
+        }
+
+        User.$adminColumnOptions = {
+            attachment: {
+                type: 'file',
+                optional: true,
+            },
+        }
+
+        const resource = application.container.make(BaseResource, [User])
+        const params = {
+            username: 'hello-world',
+            password: 'Hi!',
+            attachment: '',
+        }
+
+        const validatedData = await resource.validateParams(params)
+
+        assert.isNull(validatedData.attachment)
     })
 })
 

--- a/tests/unit/src/Adapter/BaseResource.spec.ts
+++ b/tests/unit/src/Adapter/BaseResource.spec.ts
@@ -94,7 +94,7 @@ test.group('Resource | property', (group) => {
         class User extends UserModel {
             @adminFilter('phoneNumber', { type: 'number' })
             public static async filterByPhoneNumber() {
-                return () => {}
+                return () => { }
             }
         }
 
@@ -118,7 +118,7 @@ test.group('Resource | property', (group) => {
         class User extends UserModel {
             @adminFilter('phoneNumber')
             public static async filterByPhoneNumber() {
-                return () => {}
+                return () => { }
             }
         }
 
@@ -311,7 +311,94 @@ test.group('Resource | applyFilter', (group) => {
 
         await resource.applyFilter(query, filter)
 
-        assert.isTrue(whereStub.calledOnceWith('type', UserType.ADMIN))
+        assert.isTrue(whereStub.calledOnce)
+        assert.isTrue(whereStub.calledWith('type', UserType.ADMIN))
+    })
+
+    test('skips the filter instead of throwing when the enum value is malformed', async ({
+        assert,
+        application,
+        models,
+    }) => {
+        const UserModel = models.User
+        const { column } = application.container.use('Adonis/Lucid/Orm')
+
+        enum UserType {
+            USER = 1,
+            ADMIN = 2,
+        }
+
+        class User extends UserModel {
+            @column()
+            public type: number
+        }
+
+        User.$adminColumnOptions = {
+            type: {
+                enum: UserType,
+            },
+        }
+
+        const resource = application.container.make(BaseResource, [User])
+        const query = models.User.query()
+        const filter = new Filter({ type: 'not-a-real-enum-value' }, resource)
+
+        const whereStub = sinon.stub(query, 'where')
+
+        await resource.applyFilter(query, filter)
+
+        assert.isFalse(whereStub.called)
+    })
+
+    test('a real column named the same as the reserved search path is still filtered as a column', async ({
+        assert,
+        application,
+        models,
+    }) => {
+        const UserModel = models.User
+        const { column } = application.container.use('Adonis/Lucid/Orm')
+
+        class User extends UserModel {
+            @column()
+            public search: string
+        }
+
+        const resource = application.container.make(BaseResource, [User])
+        const query = User.query()
+        const filter = new Filter({ search: 'foo' }, resource)
+
+        await resource.applyFilter(query, filter)
+
+        const { sql, bindings } = query.toSQL()
+
+        assert.include(sql, '`search` = ?')
+        assert.deepEqual(bindings, ['foo'])
+    })
+
+    test('a real column filter takes precedence over a same-named @adminFilter', async ({
+        assert,
+        application,
+        models,
+    }) => {
+        const UserModel = models.User
+
+        class User extends UserModel {
+            @adminFilter('username')
+            public static async filterByUsername(_value: string) {
+                return (builder: any) => builder.where('id', 999)
+            }
+        }
+
+        const resource = application.container.make(BaseResource, [User])
+        const query = User.query()
+        const filter = new Filter({ username: 'bob' }, resource)
+
+        await resource.applyFilter(query, filter)
+
+        const { sql, bindings } = query.toSQL()
+
+        assert.include(sql, '`username` = ?')
+        assert.deepEqual(bindings, ['bob'])
     })
 })
 
@@ -375,6 +462,41 @@ test.group(
             // never the raw filter value being applied against a `phoneNumber` column
             assert.isTrue(whereStub.calledOnce)
             assert.isFunction(whereStub.firstCall.args[0])
+        })
+
+        test('a date/datetime-typed filter receives the { from, to } range as-is, not stringified', async ({
+            assert,
+            application,
+            models,
+        }) => {
+            const UserModel = models.User
+            let received: unknown
+
+            class User extends UserModel {
+                @adminFilter('joinedAt', { type: 'date' })
+                public static async filterByJoinedAt(value: unknown) {
+                    received = value
+
+                    return () => { }
+                }
+            }
+
+            const resource = application.container.make(BaseResource, [User])
+            const query = User.query()
+            const filter = new Filter(
+                {
+                    'joinedAt~~from': '2020-01-01',
+                    'joinedAt~~to': '2020-12-31',
+                },
+                resource
+            )
+
+            await resource.applyFilter(query, filter)
+
+            assert.deepEqual(received, {
+                from: '2020-01-01',
+                to: '2020-12-31',
+            })
         })
     }
 )
@@ -991,6 +1113,41 @@ test.group('Resource | validateParams', (group) => {
         const validatedData = await resource.validateParams(params)
 
         assert.isNull(validatedData.attachment)
+    })
+
+    test('throws a validation error when clearing a required attachment', async ({
+        assert,
+        application,
+        models,
+    }) => {
+        const UserModel = models.User
+        const { column } = application.container.use('Adonis/Lucid/Orm')
+
+        class User extends UserModel {
+            @column()
+            public attachment: string
+        }
+
+        User.$adminColumnOptions = {
+            attachment: {
+                type: 'file',
+                optional: false,
+            },
+        }
+
+        const resource = application.container.make(BaseResource, [User])
+        const params = {
+            username: 'hello-world',
+            password: 'Hi!',
+            attachment: '',
+        }
+
+        try {
+            await resource.validateParams(params)
+            assert.fail('expected validateParams to throw a ValidationError')
+        } catch (e) {
+            assert.instanceOf(e, ValidationError)
+        }
     })
 })
 

--- a/tests/unit/src/Adapter/BaseResource.spec.ts
+++ b/tests/unit/src/Adapter/BaseResource.spec.ts
@@ -312,7 +312,7 @@ test.group('Resource | applyFilter', (group) => {
         await resource.applyFilter(query, filter)
 
         assert.isTrue(whereStub.calledOnce)
-        assert.isTrue(whereStub.calledWith('type', UserType.ADMIN))
+        assert.isTrue(whereStub.calledWith('type', sinon.match(UserType.ADMIN)))
     })
 
     test('skips the filter instead of throwing when the enum value is malformed', async ({

--- a/tests/unit/src/Adapter/Property.spec.ts
+++ b/tests/unit/src/Adapter/Property.spec.ts
@@ -120,6 +120,27 @@ test.group('Property | reference', () => {
 
         assert.strictEqual(property.reference(), null)
     })
+
+    test('returns null when multiple belongsTo relations share the same foreign key', ({
+        assert,
+        models,
+        application,
+    }) => {
+        const { belongsTo } = application.container.use('Adonis/Lucid/Orm')
+        const TodoListModel = models.TodoList
+
+        class TodoList extends TodoListModel {
+            @belongsTo(() => models.User, { foreignKey: 'userId' })
+            public secondaryUser: any
+        }
+
+        const property = application.container.make(Property, [
+            TodoList,
+            'userId',
+        ])
+
+        assert.isNull(property.reference())
+    })
 })
 
 test.group('Property | getSchemaType', (group) => {
@@ -331,5 +352,75 @@ test.group('Property | getSchemaType', (group) => {
             assert.isFunction(schemaType.getTree)
             assert.deepEqual(schemaType.getTree(), schema.string().getTree())
         })
+    })
+})
+
+test.group('Property | serialize', () => {
+    test('returns value as-is when attachment value is already a url string', async ({
+        assert,
+        application,
+        models,
+    }) => {
+        const UserModel = models.User
+        const { column } = application.container.use('Adonis/Lucid/Orm')
+
+        class User extends UserModel {
+            @column()
+            public attachment: string
+        }
+
+        User.$adminColumnOptions = {
+            attachment: {
+                type: 'file',
+            },
+        }
+
+        const property = application.container.make(Property, [
+            User,
+            'attachment',
+        ])
+
+        const row = new User().fill({
+            attachment: 'https://example.com/existing-file.pdf',
+        })
+
+        assert.strictEqual(
+            await property.serialize(row),
+            'https://example.com/existing-file.pdf'
+        )
+    })
+
+    test('extracts url when attachment value is an object', async ({
+        assert,
+        application,
+        models,
+    }) => {
+        const UserModel = models.User
+        const { column } = application.container.use('Adonis/Lucid/Orm')
+
+        class User extends UserModel {
+            @column()
+            public attachment: any
+        }
+
+        User.$adminColumnOptions = {
+            attachment: {
+                type: 'file',
+            },
+        }
+
+        const property = application.container.make(Property, [
+            User,
+            'attachment',
+        ])
+
+        const row = new User().fill({
+            attachment: { url: 'https://example.com/existing-file.pdf' },
+        })
+
+        assert.strictEqual(
+            await property.serialize(row),
+            'https://example.com/existing-file.pdf'
+        )
     })
 })

--- a/tests/unit/src/Adapter/decorators.spec.ts
+++ b/tests/unit/src/Adapter/decorators.spec.ts
@@ -1,4 +1,8 @@
-import { adminColumn } from '../../../../src/Adapter/decorators'
+import {
+    adminAction,
+    adminColumn,
+    adminFilter,
+} from '../../../../src/Adapter/decorators'
 import { test } from '@japa/runner'
 
 import { AdminColumnOptions } from '@ioc:Adonis/Addons/AdminJS'
@@ -24,5 +28,182 @@ test.group('decorator | adminColumn', () => {
         assert.isObject(MyUser.$adminColumnOptions)
         assert.isObject(MyUser.$adminColumnOptions!.username)
         assert.deepEqual(MyUser.$adminColumnOptions!.username, columnOptions)
+    })
+})
+
+test.group('decorator | adminFilter', () => {
+    test('registers the resolver under the given path with default options', ({
+        assert,
+        models,
+    }) => {
+        // decorators like `adminFilter`/`adminAction` call `target.boot()`, which
+        // eagerly re-boots this subclass's inherited relations. Booting infers
+        // relation keys from the class's own name, so the subclass must keep the
+        // same name as the fixture model (shadowing it via a separate binding)
+        // rather than being renamed - otherwise Lucid looks for a foreign key
+        // matching the new name (eg. "myUserId") that doesn't exist on the table.
+        const UserModel = models.User
+
+        class User extends UserModel {
+            @adminFilter('phoneNumber')
+            public static async filterByPhoneNumber(_value: string) {
+                return () => {}
+            }
+        }
+
+        assert.notExists(UserModel.$adminFilters)
+        assert.isObject(User.$adminFilters)
+        assert.isObject(User.$adminFilters!.phoneNumber)
+        assert.isUndefined(User.$adminFilters!.phoneNumber.type)
+        assert.isUndefined(User.$adminFilters!.phoneNumber.includeInSearch)
+        assert.isFunction(User.$adminFilters!.phoneNumber.resolve)
+    })
+
+    test('stores the provided type & includeInSearch options', ({
+        assert,
+        models,
+    }) => {
+        const UserModel = models.User
+
+        class User extends UserModel {
+            @adminFilter('phoneNumber', {
+                type: 'number',
+                includeInSearch: true,
+            })
+            public static async filterByPhoneNumber(_value: string) {
+                return () => {}
+            }
+        }
+
+        assert.strictEqual(User.$adminFilters!.phoneNumber.type, 'number')
+        assert.isTrue(User.$adminFilters!.phoneNumber.includeInSearch)
+    })
+
+    test('resolve calls the decorated static method bound to the model', async ({
+        assert,
+        models,
+    }) => {
+        const UserModel = models.User
+        let receivedThis: unknown
+        let receivedValue: unknown
+
+        class User extends UserModel {
+            @adminFilter('phoneNumber')
+            public static async filterByPhoneNumber(
+                this: unknown,
+                value: string
+            ) {
+                receivedThis = this
+                receivedValue = value
+
+                return () => {}
+            }
+        }
+
+        await User.$adminFilters!.phoneNumber.resolve('12345')
+
+        assert.strictEqual(receivedThis, User)
+        assert.strictEqual(receivedValue, '12345')
+    })
+
+    test('registering multiple filters on the same model keeps both', ({
+        assert,
+        models,
+    }) => {
+        const UserModel = models.User
+
+        class User extends UserModel {
+            @adminFilter('phoneNumber')
+            public static async filterByPhoneNumber(_value: string) {
+                return () => {}
+            }
+
+            @adminFilter('email')
+            public static async filterByEmail(_value: string) {
+                return () => {}
+            }
+        }
+
+        assert.isObject(User.$adminFilters!.phoneNumber)
+        assert.isObject(User.$adminFilters!.email)
+    })
+})
+
+test.group('decorator | adminAction', () => {
+    test('registers the handler under the given name with the provided options', ({
+        assert,
+        models,
+    }) => {
+        const UserModel = models.User
+
+        class User extends UserModel {
+            @adminAction('deactivate', {
+                actionType: 'record',
+                icon: 'Stop',
+                guard: 'sureToDeactivate',
+            })
+            public static async deactivate() {
+                return { notice: { message: 'ok' } }
+            }
+        }
+
+        assert.notExists(UserModel.$adminActions)
+        assert.isObject(User.$adminActions)
+
+        const action = User.$adminActions!.deactivate
+
+        assert.strictEqual(action.name, 'deactivate')
+        assert.strictEqual(action.actionType, 'record')
+        assert.strictEqual(action.icon, 'Stop')
+        assert.strictEqual(action.guard, 'sureToDeactivate')
+        assert.isFunction(action.handler)
+    })
+
+    test('handler calls the decorated static method bound to the model', async ({
+        assert,
+        models,
+    }) => {
+        const UserModel = models.User
+        let receivedThis: unknown
+
+        class User extends UserModel {
+            @adminAction('deactivate', { actionType: 'record' })
+            public static async deactivate(this: unknown) {
+                receivedThis = this
+
+                return { notice: { message: 'ok' } }
+            }
+        }
+
+        const result = await User.$adminActions!.deactivate.handler(
+            {} as any,
+            {} as any,
+            {} as any
+        )
+
+        assert.strictEqual(receivedThis, User)
+        assert.deepEqual(result, { notice: { message: 'ok' } })
+    })
+
+    test('registering multiple actions on the same model keeps both', ({
+        assert,
+        models,
+    }) => {
+        const UserModel = models.User
+
+        class User extends UserModel {
+            @adminAction('deactivate', { actionType: 'record' })
+            public static async deactivate() {
+                return {}
+            }
+
+            @adminAction('exportAll', { actionType: 'resource' })
+            public static async exportAll() {
+                return {}
+            }
+        }
+
+        assert.isObject(User.$adminActions!.deactivate)
+        assert.isObject(User.$adminActions!.exportAll)
     })
 })

--- a/tests/unit/src/Adapter/helpers.spec.ts
+++ b/tests/unit/src/Adapter/helpers.spec.ts
@@ -28,6 +28,7 @@ test.group('helpers | getAdminColumnOptions', () => {
             unique: false,
             enum: undefined,
             sortable: false,
+            searchable: false,
             optional: false,
             serialize: undefined,
         })

--- a/tests/unit/src/Plugin/router.spec.ts
+++ b/tests/unit/src/Plugin/router.spec.ts
@@ -68,6 +68,95 @@ test.group('Router | createRouteHandler', (group) => {
         )
         assert.isTrue(responseSendSpy.calledOnceWith('Sample HTML Text'))
     })
+
+    test('passes current admin from the guard named in an auth:<guard> middleware', async ({
+        assert,
+        application,
+    }) => {
+        const ssoUser = { uuid: 'sso-user' }
+        const defaultUser = { uuid: 'default-user' }
+
+        ;(ctx as any).auth = {
+            user: defaultUser,
+            use: (guard: string) => {
+                assert.strictEqual(guard, 'sso')
+
+                return { user: ssoUser }
+            },
+        }
+
+        const router = application.container.make(Router, [
+            admin,
+            {
+                enabled: true,
+                middlewares: ['auth:sso'],
+            },
+        ])
+
+        let receivedCurrentAdmin: unknown
+
+        class ControllerWithCapture {
+            public admin: AdminJS
+
+            constructor(_ctorArgs: { admin: AdminJS }, currentAdmin: unknown) {
+                this.admin = _ctorArgs.admin
+                receivedCurrentAdmin = currentAdmin
+            }
+
+            public test() {
+                return 'Sample HTML Text'
+            }
+        }
+
+        const handler = router.createRouteHandler({
+            ...route,
+            Controller: ControllerWithCapture,
+        })
+
+        await handler(ctx)
+
+        assert.strictEqual(receivedCurrentAdmin, ssoUser)
+    })
+
+    test('falls back to the default guard when no auth:<guard> middleware is configured', async ({
+        assert,
+        application,
+    }) => {
+        const defaultUser = { uuid: 'default-user' }
+
+        ;(ctx as any).auth = { user: defaultUser }
+
+        const router = application.container.make(Router, [
+            admin,
+            {
+                enabled: true,
+            },
+        ])
+
+        let receivedCurrentAdmin: unknown
+
+        class ControllerWithCapture {
+            public admin: AdminJS
+
+            constructor(_ctorArgs: { admin: AdminJS }, currentAdmin: unknown) {
+                this.admin = _ctorArgs.admin
+                receivedCurrentAdmin = currentAdmin
+            }
+
+            public test() {
+                return 'Sample HTML Text'
+            }
+        }
+
+        const handler = router.createRouteHandler({
+            ...route,
+            Controller: ControllerWithCapture,
+        })
+
+        await handler(ctx)
+
+        assert.strictEqual(receivedCurrentAdmin, defaultUser)
+    })
 })
 
 test.group('Router | createAssetHandler', (group) => {


### PR DESCRIPTION
## Summary
- Add `@adminFilter` to register virtual (non-column) filters — e.g. filtering
  by a value on a related table — via a static resolver method that returns a
  synchronous query-builder callback.
- Add a generic, OR-combined multi-column search box (`@adminColumn({ searchable: true })`,
  reserved path `SEARCH_PROPERTY_PATH`), which virtual filters can join via
  `includeInSearch: true`.
- Add `@adminAction` to register custom AdminJS actions (resource/record/bulk)
  directly on a model, auto-wired into `options.actions` — no config-file
  changes needed.
- Add a `$adminResourceOptions` static escape hatch so a model can set
  `filterProperties`/`properties`/etc. without opting out of automatic model
  discovery.
- Fix: enum filter values are now converted back to their underlying value
  before being applied to the query (previously compared the raw string
  against the stored int/enum value).
- Fix: attachment fields no longer misserialize when the submitted value is
  the existing URL string vs. a newly uploaded file object; unchanged/cleared
  attachments are handled explicitly in `validateParams`.
- Fix: a `belongsTo` reference is only resolved when exactly one relation
  matches the foreign key — previously it'd silently guess the first match for
  polymorphic-style columns.
- Fix: the current admin user is now resolved from the specific `auth:<guard>`
  middleware guard when one is configured, instead of always falling back to
  the app's default auth guard.
- `applyFilter` is now `async` and mutates the query in place instead of
  returning it (returning would trigger promise-resolution against the
  thenable query builder and execute early).

## Test plan
- [x] `yarn build` — compiles clean
- [x] `yarn lint` — clean
- [x] `tsc --noEmit` — clean